### PR TITLE
Ensure the backlight GPIO is configured correctly

### DIFF
--- a/main/st7789.c
+++ b/main/st7789.c
@@ -54,6 +54,7 @@ void spi_master_init(TFT_t * dev, int16_t GPIO_MOSI, int16_t GPIO_SCLK, int16_t 
 
 	ESP_LOGI(TAG, "GPIO_BL=%d",GPIO_BL);
 	if ( GPIO_BL >= 0 ) {
+		gpio_pad_select_gpio(GPIO_BL);
 		gpio_set_direction( GPIO_BL, GPIO_MODE_OUTPUT );
 		gpio_set_level( GPIO_BL, 0 );
 	}


### PR DESCRIPTION
The back light GPIO may not be configured as a GPIO on some systems (it is not on my TTGO T-WATCH-2020). 
Add gpio_pad_select_gpio( GPIO_CS ) to ensure that it is configured correctly.